### PR TITLE
Rename `override` to `overwrite`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ module.exports = {
       apiKey: 'e48e13207341b6bffb7fb1622282247b', // required
       publicPath: 'http*://*example.com/build', // or `output.publicPath`
       appVersion: '1.7.0',
-      override: true
+      overwrite: true
     })
   ]
 };

--- a/src/BugsnagSourceMapPlugin.js
+++ b/src/BugsnagSourceMapPlugin.js
@@ -7,14 +7,14 @@ class BugsnagSourceMapPlugin extends CommonBugsnagPlugin {
     apiKey = null,
     publicPath = null,
     appVersion = null,
-    override = false,
+    overwrite = false,
   }) {
     super();
     this.options = {
       apiKey,
       publicPath,
       appVersion,
-      override,
+      overwrite,
     };
     this.validateOptions();
   }
@@ -64,8 +64,8 @@ class BugsnagSourceMapPlugin extends CommonBugsnagPlugin {
   }
 
   getUploadOptions(compilation) {
-    const { apiKey, appVersion, override } = this.options;
-    const uploadOptions = { apiKey, appVersion, override };
+    const { apiKey, appVersion, overwrite } = this.options;
+    const uploadOptions = { apiKey, appVersion, overwrite };
     if (appVersion) {
       return Promise.resolve(uploadOptions);
     } else {


### PR DESCRIPTION
This breaks the API, but I think it just makes way more sense to call it overwrite since that's the name of the option in Bugsnag, and actually means what it does--override sounds like changing functionality.