### PR TITLE
add missing import for getSafeRepositoryUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This module contains webpack plugins to help ease Bugsnag into your webpack buil
 The Bugsnag plugins are available on npm, you can install them into your project by running the following command in the root of your project.
 
 ```sh
-$ npm i --save webpack-bugsnag-plugin
+$ npm i --save-dev webpack-bugsnag-plugin
 ```
 
 ## Usage

--- a/src/helpers/package.js
+++ b/src/helpers/package.js
@@ -1,4 +1,7 @@
 import pkgUp from 'pkg-up';
+import {
+  getSafeRepositoryUrl,
+} from './git';
 
 const REPOSITORY_STRING_REGEX = /((gist|bitbucket|gitlab):)?(\w+)\/(\w+)/;
 


### PR DESCRIPTION
``getSafeRepositoryUrl`` is not being imported into [src/helpers/package.js](https://github.com/jacobmarshall/webpack-bugsnag-plugin/blob/master/src/helpers/package.js#L51), which causes this error: 

> ERROR in BugsnagDeployPlugin (getSafeRepositoryUrl is not defined)