### PR TITLE
Propogate endpoint option to bugsnag plugin

### DIFF
--- a/src/BugsnagSourceMapPlugin.js
+++ b/src/BugsnagSourceMapPlugin.js
@@ -8,6 +8,7 @@ class BugsnagSourceMapPlugin extends CommonBugsnagPlugin {
     publicPath = null,
     appVersion = null,
     overwrite = false,
+    endpoint = 'https://upload.bugsnag.com',
   }) {
     super();
     this.options = {
@@ -15,6 +16,7 @@ class BugsnagSourceMapPlugin extends CommonBugsnagPlugin {
       publicPath,
       appVersion,
       overwrite,
+      endpoint,
     };
     this.validateOptions();
   }
@@ -64,8 +66,8 @@ class BugsnagSourceMapPlugin extends CommonBugsnagPlugin {
   }
 
   getUploadOptions(compilation) {
-    const { apiKey, appVersion, overwrite } = this.options;
-    const uploadOptions = { apiKey, appVersion, overwrite };
+    const { apiKey, appVersion, overwrite, endpoint } = this.options;
+    const uploadOptions = { apiKey, appVersion, overwrite, endpoint };
     if (appVersion) {
       return Promise.resolve(uploadOptions);
     } else {


### PR DESCRIPTION
Hi,
I see in the docs you have an option for endpoint to be set for bugsnag enterprise edition, but it doesn't seem to actually be implemented.  I've created a PR to implement it.
Thanks,