### PR TITLE
Adds support for query strings

### DIFF
--- a/src/BugsnagSourceMapPlugin.js
+++ b/src/BugsnagSourceMapPlugin.js
@@ -37,8 +37,10 @@ class BugsnagSourceMapPlugin extends CommonBugsnagPlugin {
     publicPath += /\/$/.test(publicPath) ? '' : '/';
 
     stats.chunks.forEach(chunk => {
-      const [ file ] = chunk.files.filter(file => /\.js$/.test(file));
-      const [ sourceMap ] = chunk.files.filter(file => /\.js\.map$/.test(file));
+
+      const filesWithoutQuery = chunk.files.map(file => this.removeQueryString(file));
+      const [ file ] = filesWithoutQuery.filter(file => /\.js$/.test(file));
+      const [ sourceMap ] = filesWithoutQuery.filter(file => /\.js\.map$/.test(file));
 
       if (sourceMap) {
         sourceMaps.push({
@@ -50,6 +52,21 @@ class BugsnagSourceMapPlugin extends CommonBugsnagPlugin {
     });
 
     return sourceMaps;
+  }
+
+  removeQueryString (fileName) {
+    // Part of the challenge here is that '?' is a valid character in
+    // unix file systems. This at least checks for a '?' following the
+    // extension(s) we are interested in.
+    const extensions = ['.js', '.js.map'];
+    let result = fileName;
+    extensions.some(extension => {
+      if (fileName.includes(`${extension}?`)) {
+        result = fileName.split(`${extension}?`)[0] + extension;
+        return true;
+      }
+    });
+    return result;
   }
 
   uploadSourceMaps(options, sourceMaps) {

--- a/src/BugsnagSourceMapPlugin.js
+++ b/src/BugsnagSourceMapPlugin.js
@@ -48,6 +48,8 @@ class BugsnagSourceMapPlugin extends CommonBugsnagPlugin {
           file: path.resolve(outputPath, file),
           sourceMap: path.resolve(outputPath, sourceMap),
         });
+      } else {
+        console.log('webpack-bugsnag-plugin: no sourcemap found for', file);
       }
     });
 
@@ -71,14 +73,15 @@ class BugsnagSourceMapPlugin extends CommonBugsnagPlugin {
 
   uploadSourceMaps(options, sourceMaps) {
     return Promise.all(
-      sourceMaps.map(({ url, file, sourceMap }) => (
-        upload({
+      sourceMaps.map(({ url, file, sourceMap }) => {
+        console.log('webpack-bugsnag-plugin: uploading', sourceMap);
+        return upload({
           ...options,
           minifiedUrl: url,
           minifiedFile: file,
           sourceMap: sourceMap,
         })
-      ))
+      })
     );
   }
 


### PR DESCRIPTION
Webpack allows query strings to be added to output filenames.  This PR is to support them.

There are also some 'console.log' messages added to log if source maps were found, and what is being uploaded.

Issue: #6